### PR TITLE
Fix auth config and service error logging

### DIFF
--- a/core/modules/services.py
+++ b/core/modules/services.py
@@ -39,12 +39,12 @@ def run_service_operation(service_name, op):
             process = subprocess.run(path, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
         else:
             process = subprocess.run(["sudo", "systemctl", op, service_name], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
-        
+
         logging.info("Running - " + service_name + " " + op)
         po.send_notification(service_name + " " + op, 0)
         return True
-    except:
-        logging.error(process.stderr)
+    except Exception as e:
+        logging.error(getattr(e, "stderr", str(e)))
         return False
     
 def run_command(cmd: list[str]):

--- a/hub/controller/server.js
+++ b/hub/controller/server.js
@@ -15,9 +15,9 @@ if (inProduction()) {
     authRequired: false,
     auth0Logout: true,
     secret: config.auth0.client_secret,
-    baseURL: config.auth0.client_secret,
-    clientID: config.auth0.client_secret,
-    issuerBaseURL: config.auth0.client_secret
+    baseURL: config.baseURL,
+    clientID: config.auth0.client_id,
+    issuerBaseURL: config.auth0.base_url
   };
 
   app.use(auth(auth_config));


### PR DESCRIPTION
## Summary
- fix the auth0 config mapping in the controller
- handle subprocess errors correctly in the services module

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6851707f82108329b23c6fa1550905ed